### PR TITLE
Option to enable notification in full screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ set -U __done_exclude 'git (?!push|pull)'  # default: all git commands, except p
 set -U __done_notification_command 'some custom command'
 ```
 
+#### Display notification even in full screen mode
+```bash
+set -U __done_notify_in_fullscreen 1
+```
+
 
 ## Support
 - fish 2.3.0+

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -105,6 +105,7 @@ and test -n __done_get_focused_window_id  # is able to get window id
 			else if type -q notify-send # Linux notify-send
 				set -l urgency
 				if test $exit_status -ne 0
+				or test $__done_notify_in_fullscreen -eq 1
 					set urgency "--urgency=critical"
 				end
 				notify-send $urgency --icon=terminal --app-name=fish "$title" "$message"


### PR DESCRIPTION
This PR for LINUX (ubuntu) allows to always have the notification, even in fullscreen when you're playing a game or watching a video. Just need to set the var in your config

I spent a unhealthy amount of time trying to make the "or" works -__- this is ridiculous

I also figured that it will prob cause an error when the variable is not set, so I hope you can fix it/show me how to fix it.