### PR TITLE
chore: update humanize-duration dependency

### DIFF
--- a/fishfile
+++ b/fishfile
@@ -1,1 +1,1 @@
-jorgebucaran/FISH-humanize_duration
+fishpkg/fish-humanize-duration


### PR DESCRIPTION
fish-humanize-duration has a new home: https://github.com/fishpkg/fish-humanize-duration.