### PR TITLE
Improve README instructions & presentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_install:
 script:
     - fish --version
     - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisherman
-    - fish -c "fisher i fishtape .; fishtape test/*.fish"
+    - fish -c "fisher add jorgebucaran/fishtape .; fishtape test/*.fish"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <br>
 </h1>
 
-<h4 align="center">A <a href="https://fishshell.com/">fish</a> plugin to automatically receive notifications when long processes finish.</h4>
+<h4 align="center">A <a href="https://fishshell.com/">fish shell</a> package to automatically receive notifications when long processes finish.</h4>
 
 <p align="center">
   <img src="https://img.shields.io/badge/stability-stable-green.svg" alt="Stability: Stable">
@@ -17,66 +17,73 @@ Just go on with your normal life. You will get a notification when a process tak
 
 After installing you could type, for instance `sleep 6`, and start using other app. After 6 seconds you should get a notification.
 
+## Installation
 
+#### Using [Fisher](https://github.com/jorgebucaran/fisher)
 
-## Install
-
-
-#### Using [fisherman](https://github.com/jorgebucaran/fisher)
-```bash
+```fish
 fisher add franciscolourenco/done
 ```
 
 #### Manually
-```bash
-curl -Lo ~/.config/fish/functions/humanize_duration.fish --create-dirs https://raw.githubusercontent.com/fisherman/humanize_duration/master/humanize_duration.fish
+
+```fish
+curl -Lo ~/.config/fish/functions/humanize_duration.fish --create-dirs https://raw.githubusercontent.com/fishpkg/fish-humanize-duration/master/humanize_duration.fish
 curl -Lo ~/.config/fish/conf.d/done.fish --create-dirs https://raw.githubusercontent.com/franciscolourenco/done/master/conf.d/done.fish
 ```
 
 ## Dependencies
+
 If you want notifications with icons on macOS, please install `terminal-notifier`
 
-```bash
+```fish
 brew install terminal-notifier
 ```
 
-## Update
+## Updating
 
-```bash
-fisher update
+```fish
+fisher
 ```
 
 [Subscribe](http://eepurl.com/cAcU3P) to the newsletter to be notified of new versions.
 
 ## Settings
 
-
 #### Only display notifications if a command takes more than a certain amount of time
-```bash
+
+```fish
 `set -U __done_min_cmd_duration 5000  # default: 5000 ms`
 ```
 
 #### Prevent specific commands from triggering notifications. Accepts a regex.
+
 This is useful to exclude commands like `git commit` for instance, since it could trigger unwanted notifications if it is configured to use an external editor.
 
-```bash
+```fish
 
 set -U __done_exclude 'git (?!push|pull)'  # default: all git commands, except push and pull. accepts a regex.
 ```
 
 #### Execute a custom command instead of showing the default notifications
-```bash
+
+```fish
 set -U __done_notification_command 'some custom command'
 ```
 
-
 ## Support
-- fish 2.3.0+
+
+- [fish](https://fishshell.com) 2.3.0+
 - macOS 10.8+ via Notification Center.
 - Linux via `notify-send`. Otherwise bell sound is played.
 - Windows: Upvote https://github.com/franciscolourenco/done/issues/5 if interested.
 
 ## Credits
+
 - [Francisco Lourenço](https://github.com/aristidesfl/) - Maintainer
 - [Daniel Wehner](https://dawehner.github.io/) - Proof of Concept
 - [Thanh Duc Nguyen](http://iamthanh.com/) - Logo
+
+## License
+
+Done is MIT licensed. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
This PR improves the README presentation, indentation, and instructions.

- Replaces ~~fisherman~~ with Fisher
- Replaces <code>\`bash</code> with <code>\`fish</code>
- Replaces "plugin" with "package"
- Adds License section with a link to the LICENSE file
- Updates .travis.yml to use Fisher (although it's still broken because of https://github.com/jorgebucaran/fisher/issues/513)
- Adds a link to https://fishshell.com in dependencies section


@franciscolourenco The only thing I can't include to this PR is changing your GitHub repository tags. Could you change:

- `fish-plugin` to **`fish-packages`** and
- `fisherman` to `fisher` please?

Cheers.