### PR TITLE
Add support for notify-desktop on Linux

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -108,6 +108,13 @@ and test -n __done_get_focused_window_id  # is able to get window id
 					set urgency "--urgency=critical"
 				end
 				notify-send $urgency --icon=terminal --app-name=fish "$title" "$message"
+				
+			else if type -q notify-desktop # Linux notify-desktop
+				set -l urgency
+				if test $exit_status -ne 0
+					set urgency "--urgency=critical"
+				end
+				notify-desktop $urgency --icon=terminal --app-name=fish "$title" "$message"
 
 			else  # anything else
 				echo -e "\a" # bell sound


### PR DESCRIPTION
Add support for notify-desktop on Linux

[nowrep/notify-desktop](https://github.com/nowrep/notify-desktop):

> Little application that lets you send desktop notifications with one command. It's basically clone of notify-send from libnotify, but it supports reusing notifications on screen by passing its ID. It also does not use any external dependencies (except from libdbus of course).