### PR TITLE
Add support for `sway`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you want notifications with icons on macOS, please install `terminal-notifier
 brew install terminal-notifier
 ```
 
+If you are using `sway` then please install `jq`.
+
 ## Updating
 
 ```fish

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -25,6 +25,9 @@ set -g __done_version 1.8.1
 function __done_get_focused_window_id
 	if type -q lsappinfo
 		lsappinfo info -only bundleID (lsappinfo front) | cut -d '"' -f4
+	else if test $SWAYSOCK
+	and type -q jq
+		swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
 	else if type -q xprop
 	and test $DISPLAY
 		xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2


### PR DESCRIPTION
This PR adds support for [sway](https://github.com/swaywm/sway), which is a Wayland compositor.

The current code uses `xprop` to get window IDs, however this does not work for non-X11 sessions.

With this PR the `$SWAYSOCK` env var is first checked to see if `sway` is running, and if so, a sway specific command is used to get window IDs. If sway is not running then it should work exactly the same as it is now.

Tested with sway 1.2-rc1 and is working well so far. (Cheers for the great fish plugin!)

Note: `jq` is required in order to parse the swaymsg output for the currently focused window ID. If someone has a better or dependency-less method then feel free to comment.