### PR TITLE
Quote arguments for `test` command

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -25,11 +25,11 @@ set -g __done_version 1.10.0
 function __done_get_focused_window_id
 	if type -q lsappinfo
 		lsappinfo info -only bundleID (lsappinfo front) | cut -d '"' -f4
-	else if test $SWAYSOCK
+	else if test -n "$SWAYSOCK"
 	and type -q jq
 		swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
 	else if type -q xprop
-	and test $DISPLAY
+	and test -n "$DISPLAY"
 		xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2
 	end
 end


### PR DESCRIPTION
1. Quoted the arguments to the `test` commands used in the code to adhere to best practice.
> Since it is always safe to enclose variables in double-quotes when used as `test` arguments that is the recommended practice.

2. Add `-n` argument as we want to check that the variable is "defined and not empty".