### PR TITLE
Enclose test argument with double-quotes

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -42,7 +42,7 @@ end
 
 function __done_is_process_window_focused
 	# Return false if the window is not focused
-	if test $__done_initial_window_id != (__done_get_focused_window_id)
+	if test "$__done_initial_window_id" != (__done_get_focused_window_id)
 		return 1
 	end
 	# If inside a tmux session, check if the tmux window is focused


### PR DESCRIPTION
Found this when investigating the cause of https://github.com/fish-shell/fish-shell/issues/6350.

From fish docs:
> If the variable is not set, set but with no value, or set to more than one value you must enclose it in double-quotes.