### PR TITLE
Add support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ brew install terminal-notifier
 
 - If you are using https://swaywm.org please install `jq`.
 
+- If you are using Windows Subsystem for Linux (WSL), please install the [BurntToast](https://github.com/Windos/BurntToast) Powershell module. 
+
 ## Updating
 
 ```fish
@@ -81,7 +83,7 @@ set -U __done_notify_sound 1
 - [fish](https://fishshell.com) 2.3.0+
 - macOS 10.8+ via Notification Center.
 - Linux via `notify-send`. Otherwise bell sound is played.
-- Windows: Upvote https://github.com/franciscolourenco/done/issues/5 if interested.
+- Windows 10 via Windows Subsystem for Linux (WSL) and [BurntToast](https://github.com/Windos/BurntToast)
 
 ## Credits
 

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -31,6 +31,8 @@ function __done_get_focused_window_id
 	else if type -q xprop
 	and test -n "$DISPLAY"
 		xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2
+	else if uname -a | string match --quiet --regex Microsoft
+		echo 12345  # dummy value since cannot get window state info under WSL
 	end
 end
 
@@ -130,6 +132,14 @@ and count (__done_get_focused_window_id) > /dev/null  # is able to get window id
 					echo -e "\a" # bell sound
 				end
 
+			else if uname -a | string match --quiet --regex Microsoft
+				if powershell.exe -command "Import-Module -Name BurntToast" 2> /dev/null
+					if test "$__done_notify_sound" -eq 1
+						set soundopt "-Sound Default"
+					end
+					powershell.exe -command New-BurntToastNotification -Text \""$title"\",\""$message"\" $soundopt
+				end
+
 			else  # anything else
 				echo -e "\a" # bell sound
 			end
@@ -149,4 +159,3 @@ function __done_uninstall -e done_uninstall
   # Erase __done variables
   set -e __done_version
 end
-


### PR DESCRIPTION
Solves #5 

Screenshot:
![image](https://user-images.githubusercontent.com/20397027/69528819-56053a80-0fb2-11ea-957b-1d3eb1b2a04c.png)

Prerequisites:
-  `BurntToast` notification plugin for Powershell
- `fish` running under WSL (Windows Subsystem for Linux)
- Windows 10 (since only 10 has WSL)