### PR TITLE
Enclose second arg to test with double-quotes

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -42,7 +42,7 @@ end
 
 function __done_is_process_window_focused
 	# Return false if the window is not focused
-	if test "$__done_initial_window_id" != (__done_get_focused_window_id)
+	if test "$__done_initial_window_id" != "(__done_get_focused_window_id)"
 		return 1
 	end
 	# If inside a tmux session, check if the tmux window is focused


### PR DESCRIPTION
Missed this in #59 

On sway, when the screen is locked all containers lose focus and hence `__done_get_focused_window_id` returns a null value, which results in the following error when `done` runs:

```
test: Missing argument at index 2

~/.config/fish/conf.d/done.fish (line 45): 
	if test "$__done_initial_window_id" != (__done_get_focused_window_id)
	  ^
in function '__done_is_process_window_focused'
	called on line 80 of file ~/.config/fish/conf.d/done.fish
in function '__done_ended'
in event handler: handler for generic event “fish_prompt”

(Type 'help test' for related documentation)
```