### PR TITLE
Don't fail when powershell.exe is missing

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -154,13 +154,17 @@ if test -z "$SSH_CLIENT" # not over ssh
                     echo -e "\a" # bell sound
                 end
 
-            else if uname -a | string match --quiet --regex Microsoft
-                if command -v powershell.exe; and powershell.exe -command "Import-Module -Name BurntToast" 2>/dev/null
-                    if test "$__done_notify_sound" -eq 1
-                        set soundopt "-Sound Default"
-                    end
-                    powershell.exe -command New-BurntToastNotification -Text \""$title"\",\""$message"\" $soundopt
+            else if uname -a | string match --quiet --regex Microsoft; \
+                and set -l powershell_exe (command -v "powershell.exe"); \
+                or set -l powershell_exe \
+                    (wslpath (wslvar windir)/System32/WindowsPowerShell/v1.0/powershell.exe); \
+                and test -x "$powershell_exe"; \
+                and "$powershell_exe" -command "Import-Module -Name BurntToast" 2>/dev/null
+
+                if test "$__done_notify_sound" -eq 1
+                    set soundopt "-Sound Default"
                 end
+                command "$powershell_exe" -command New-BurntToastNotification -Text \""$title"\",\""$message"\" $soundopt
 
             else # anything else
                 echo -e "\a" # bell sound

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -155,7 +155,7 @@ if test -z "$SSH_CLIENT" # not over ssh
                 end
 
             else if uname -a | string match --quiet --regex Microsoft
-                if powershell.exe -command "Import-Module -Name BurntToast" 2>/dev/null
+                if command -v powershell.exe; and powershell.exe -command "Import-Module -Name BurntToast" 2>/dev/null
                     if test "$__done_notify_sound" -eq 1
                         set soundopt "-Sound Default"
                     end


### PR DESCRIPTION
On some platforms, `uname -a` contains `Microsoft` but `powershell.exe` is not in `$PATH`, so `if powershell.exe ... 2>/dev/null` still displays an error:

```
if powershell.exe -command "Import-Module -Name BurntToast" 2>/dev/null; echo true; end
powershell.exe: command not found
fish:
if powershell.exe -command "Import-Module -Name BurntToast" 2>/dev/null; echo true; end
   ^
```

Add a check to `command -v powershell.exe` to avoid the error message.