### PR TITLE
Add option to ignore visible windows in sway

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ set -U __done_notification_command 'some custom command'
 set -U __done_notify_sound 1
 ```
 
+#### When using `sway`, do not show notifications for visible windows.
+
+```fish
+set -U __done_sway_ignore_visible 1
+```
+
 ## Support
 
 - [fish](https://fishshell.com) 2.3.0+

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -59,7 +59,11 @@ end
 function __done_is_process_window_focused
     # Return false if the window is not focused
     set __done_focused_window_id (__done_get_focused_window_id)
-    if test "$__done_initial_window_id" != "$__done_focused_window_id"
+    if test "$__done_sway_ignore_visible" -eq 1
+        and test -n "$SWAYSOCK"
+        string match --quiet --regex "^true" (swaymsg -t get_tree | jq ".. | objects | select(.id == "$__done_initial_window_id") | .visible")
+        return $status
+    else if test "$__done_initial_window_id" != "$__done_focused_window_id"
         return 1
     end
     # If inside a tmux session, check if the tmux window is focused
@@ -88,6 +92,7 @@ if test -z "$SSH_CLIENT" # not over ssh
     set -q __done_min_cmd_duration; or set -g __done_min_cmd_duration 5000
     set -q __done_exclude; or set -g __done_exclude 'git (?!push|pull)'
     set -q __done_notify_sound; or set -g __done_notify_sound 0
+    set -q __done_sway_ignore_visible; or set -g __done_sway_ignore_visible 0
 
     function __done_started --on-event fish_preexec
         set __done_initial_window_id (__done_get_focused_window_id)


### PR DESCRIPTION
## Motivation
In a tiling window desktop environment, such as `sway`, windows do not overlap hence they are technically still in the "foreground" even if they are not currently focused (see screenie below). 

![20200117_23h40m26s](https://user-images.githubusercontent.com/20397027/72620518-ca40d680-3982-11ea-8621-0769855f6a96.png)

When using `done` in such an environment, it would be preferable if notifications were only sent if the window was not visible at all (due to being on another workspace etc). For example, in the case of the screenshot above, one might not want `done` to send a notification even if the window no longer has focus.

This PR adds an option to enable the above behaviour.


