### PR TITLE
Test if xprop works before using it

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -30,6 +30,7 @@ function __done_get_focused_window_id
         swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
     else if type -q xprop
         and test -n "$DISPLAY"
+        and xprop ^/dev/null
         xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2
     else if uname -a | string match --quiet --regex Microsoft
         echo 12345 # dummy value since cannot get window state info under WSL


### PR DESCRIPTION
This allows done to work when `DISPLAY` is set, but na X server is running.

![image](https://user-images.githubusercontent.com/74385/77835581-39685180-71a2-11ea-9da4-8d931121621e.png)

This can be common in setups where X servers are meant to work externally, eg, on WSL + Vcxsrv. Some might have `DISPLAY` set prematurely.