### PR TITLE
allow xprop to be annyoingly picky about how it is asked for help

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -26,15 +26,15 @@ function __done_get_focused_window_id
     if type -q lsappinfo
         lsappinfo info -only bundleID (lsappinfo front) | cut -d '"' -f4
     else if test -n "$SWAYSOCK"
-            and type -q jq
+        and type -q jq
         swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
     else if type -q xprop
-            and test -n "$DISPLAY"
-            and begin
-                xprop -help
-                # some versions of xprop raise error code to -help
-                or xprop -grammar
-            end >/dev/null 2>&1
+        and test -n "$DISPLAY"
+        and begin
+            xprop -help
+            # some versions of xprop raise error code to -help
+            or xprop -grammar
+        end >/dev/null 2>&1
         xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2
     else if uname -a | string match --quiet --regex Microsoft
         echo 12345 # dummy value since cannot get window state info under WSL

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -30,11 +30,8 @@ function __done_get_focused_window_id
         swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
     else if type -q xprop
         and test -n "$DISPLAY"
-        and begin
-            xprop -help
-            # some versions of xprop raise error code to -help
-            or xprop -grammar
-        end >/dev/null 2>&1
+        # Test that the X server at $DISPLAY is running
+        and xprop -grammar >/dev/null 2>&1
         xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2
     else if uname -a | string match --quiet --regex Microsoft
         echo 12345 # dummy value since cannot get window state info under WSL

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -26,11 +26,15 @@ function __done_get_focused_window_id
     if type -q lsappinfo
         lsappinfo info -only bundleID (lsappinfo front) | cut -d '"' -f4
     else if test -n "$SWAYSOCK"
-        and type -q jq
+            and type -q jq
         swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
     else if type -q xprop
-        and test -n "$DISPLAY"
-        and xprop -help 2>&1 >/dev/null
+            and test -n "$DISPLAY"
+            and begin
+                xprop -help
+                # some versions of xprop raise error code to -help
+                or xprop -grammar
+            end >/dev/null 2>&1
         xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2
     else if uname -a | string match --quiet --regex Microsoft
         echo 12345 # dummy value since cannot get window state info under WSL


### PR DESCRIPTION
Fixes the requested re-opening of #77 which seems tied to a mis-behaving xprop config.

This just allows us to consider `xprop` as working if it responds correctly to either the `-help` or `-grammar` flags.