### PR TITLE
Detect focused window correctly under GNOME Shell + Wayland

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -46,6 +46,8 @@ function __done_get_focused_window_id
     else if test -n "$SWAYSOCK"
         and type -q jq
         swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
+    else if begin test "$XDG_SESSION_DESKTOP" = gnome; and type -q gdbus; end
+	gdbus call --session --dest org.gnome.Shell --object-path /org/gnome/Shell --method org.gnome.Shell.Eval 'global.display.focus_window.get_id()'
     else if type -q xprop
         and test -n "$DISPLAY"
         # Test that the X server at $DISPLAY is running


### PR DESCRIPTION
The `xprop` strategy for checking window focus presumably works correctly when GNOME Shell is using X11. However, when GNOME Shell is using Wayland, the focused window is always reported as `0x0` regardless of what actually has focus.

My understanding is that Wayland in general does not have a "current focused window" concept at all. Any specific Wayland-based compositor might have such a concept, though. GNOME Shell does have such a concept, and exposes an API for checking the current window focus via JavaScript. We can use the session D-Bus to pass JavaScript to GNOME Shell for evaluation. This should work the same regardless of whether GNOME Shell is using Wayland or X11.