### PR TITLE
Use correct terminal icon for Linux notifications

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -175,7 +175,7 @@ if test -z "$SSH_CLIENT" # not over ssh
                 if test $exit_status -ne 0
                     set urgency "--urgency=critical"
                 end
-                notify-send $urgency --icon=terminal --app-name=fish "$title" "$message"
+                notify-send $urgency --icon=utilities-terminal --app-name=fish "$title" "$message"
                 if test "$__done_notify_sound" -eq 1
                     echo -e "\a" # bell sound
                 end
@@ -185,7 +185,7 @@ if test -z "$SSH_CLIENT" # not over ssh
                 if test $exit_status -ne 0
                     set urgency "--urgency=critical"
                 end
-                notify-desktop $urgency --icon=terminal --app-name=fish "$title" "$message"
+                notify-desktop $urgency --icon=utilities-terminal --app-name=fish "$title" "$message"
                 if test "$__done_notify_sound" -eq 1
                     echo -e "\a" # bell sound
                 end


### PR DESCRIPTION
`terminal` is not among the [Freedesktop standard icon names](https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html). On GNOME 3.36 as shipped with Fedora 32, this results in a notification with an generic placeholder icon:

> ![image](https://user-images.githubusercontent.com/1759836/81507352-d3a3d500-92ca-11ea-9b70-b918489e24cd.png)

The proper standard icon name is `utilities-terminal`, which results in a notification with a suitable terminal icon:

> ![image](https://user-images.githubusercontent.com/1759836/81507364-eae2c280-92ca-11ea-82ff-398ff1a96473.png)
