### PR TITLE
Support transient notifications

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -249,7 +249,7 @@ if set -q __done_enabled
 
                 # make notification auto-disappear
                 set -l transient ""
-                if "$__done_notification_transient" = 1
+                if "$__done_notification_transient" != 0
                     set transient --hint=int:transient:1
                 end
                 

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -247,7 +247,13 @@ if set -q __done_enabled
                     set urgency "critical"
                 end
 
-                notify-send --urgency=$urgency --icon=utilities-terminal --app-name=fish "$title" "$message"
+                # make notification auto-disappear
+                set -l transient ""
+                if "$__done_notification_transient" = 1
+                    set transient --hint=int:transient:1
+                end
+                
+                notify-send $transient --urgency=$urgency --icon=utilities-terminal --app-name=fish "$title" "$message"
 
                 if test "$__done_notify_sound" -eq 1
                     echo -e "\a" # bell sound


### PR DESCRIPTION
With this patch, if the user does `set -U __done_notification_transient 1`, these will disappear automatically on Linux systems.

See https://gist.github.com/carsondarling/6217755 for details.