### PR TITLE
Add config for urgency of failed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ set -U __done_notify_sound 1
 set -U __done_sway_ignore_visible 1
 ```
 
-#### For Linux, set the urgency level for notifications sent via notify-send (low, normal, critical).
+#### For Linux, set the urgency level for notifications sent via notify-send (low, normal, critical). The default is "normal" for regular commands, and "critical" for failed commands.
 
 ```fish
-set -U __done_notification_urgency_level critical
+set -U __done_notification_urgency_level low
+set -U __done_notification_urgency_level_failure normal
 ```
 
 #### Allow notifications to be sent on systems without graphical capabilities. Note this requires you to also set `__done_notification_command`.

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -245,6 +245,9 @@ if set -q __done_enabled
                 # override user-defined urgency level if non-zero exitstatus
                 if test $exit_status -ne 0
                     set urgency "critical"
+                    if set -q __done_notification_urgency_level_failure
+                        set urgency "$__done_notification_urgency_level_failure"
+                    end
                 end
 
                 notify-send --urgency=$urgency --icon=utilities-terminal --app-name=fish "$title" "$message"


### PR DESCRIPTION
Previously the urgency config only applied to successful commands in
send-notify, while failed commands always used "critical" urgency.

This implement the suggestion in #103.