### PR TITLE
Add `git fetch` to default `$__done_exclude`

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -189,7 +189,7 @@ end
 if set -q __done_enabled
     set -g __done_initial_window_id ''
     set -q __done_min_cmd_duration; or set -g __done_min_cmd_duration 5000
-    set -q __done_exclude; or set -g __done_exclude 'git (?!push|pull)'
+    set -q __done_exclude; or set -g __done_exclude 'git (?!push|pull|fetch)'
     set -q __done_notify_sound; or set -g __done_notify_sound 0
     set -q __done_sway_ignore_visible; or set -g __done_sway_ignore_visible 0
 


### PR DESCRIPTION
I assume this makes sense since `git pull` already implies `git fetch`.