### PR TITLE
Fix issue with ps format options

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -112,7 +112,7 @@ function __done_is_tmux_window_active
     # ppid == "tmux" -> break
     set tmux_fish_pid $fish_pid
     while set tmux_fish_ppid (ps -o ppid= -p $tmux_fish_pid | string trim)
-            and test ! (basename (ps -o exe= -p $tmux_fish_ppid)) = "tmux"
+            and test ! (basename (ps -o command= -p $tmux_fish_ppid) | string match "tmux*")
         set tmux_fish_pid $tmux_fish_ppid
     end
 

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -112,7 +112,7 @@ function __done_is_tmux_window_active
     # ppid == "tmux" -> break
     set tmux_fish_pid $fish_pid
     while set tmux_fish_ppid (ps -o ppid= -p $tmux_fish_pid | string trim)
-            and test ! (basename (ps -o command= -p $tmux_fish_ppid) | string match "tmux*")
+            and ! string match -q "tmux*" (basename (ps -o command= -p $tmux_fish_ppid))
         set tmux_fish_pid $tmux_fish_ppid
     end
 


### PR DESCRIPTION
#105 introduced a call to `ps -o exe=` but `exe` isn't a standard option and not found in some versions of `ps`.

Changing `exe` to `command` fixes this issue. The `command` option is found in Linux, MacOS, FreeBSD, OpenBSD man pages for `ps` and should therefore be available.

Tested on NixOS

Fixes #109 