### PR TITLE
Accept any exe name starting with "tmux" as tmux process

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -111,7 +111,7 @@ function __done_is_tmux_window_active
     # ppid == "tmux" -> break
     set tmux_fish_pid $fish_pid
     while set tmux_fish_ppid (ps -o ppid= -p $tmux_fish_pid | string trim)
-            and test ! (basename (ps -o exe= -p $tmux_fish_ppid)) = "tmux"
+            and string match -r -q "tmux*" (basename (ps -o exe= -p $tmux_fish_ppid))
         set tmux_fish_pid $tmux_fish_ppid
     end
 


### PR DESCRIPTION
Exe name of tmux may became "tmux (deleted)" after a system update.