### PR TITLE
Skip the config if not in interactive mode

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+status is-interactive || exit
+
 set -g __done_version 1.16.2
 
 function __done_run_powershell_script

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -20,7 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-status is-interactive || exit
+if not status is-interactive
+    exit
+end
 
 set -g __done_version 1.16.2
 


### PR DESCRIPTION
The title is self-explanatory, but I will elaborate a bit: this will speed up plugins making use of subshells, for example [tide](https://github.com/IlanCosman/tide) (prompt item functions run in subshell) and [fzf.fish](https://github.com/PatrickF1/fzf.fish) (fzf's preview run in subshell).

I'm not sure if this change will break some things potentially, but as far as I can tell, not likely.