### PR TITLE
Fix transient notification check

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -258,7 +258,7 @@ if set -q _done_enabled
 
                 # make notification auto-disappear
                 set -l transient ""
-                if "$__done_notification_transient" != 0
+                if test "$__done_notification_transient" -eq 1
                     set transient --hint=int:transient:1
                 end
                 


### PR DESCRIPTION
Previous implementation was throwing the following error:
```
fish: Unknown command: 1
~/.config/fish/conf.d/done.fish (line 261):
                if "$__done_notification_transient" != 0
                   ^
in function '__done_ended'
in event handler: handler for generic event “fish_prompt”
```

Changed variable verification to use `test`, like the remaining verifications.