### PR TITLE
Prevent inspecting a process that doesn't exist

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -116,6 +116,7 @@ function __done_is_tmux_window_active
     # ppid == "tmux" -> break
     set tmux_fish_pid $fish_pid
     while set tmux_fish_ppid (ps -o ppid= -p $tmux_fish_pid | string trim)
+        and test $tmux_fish_ppid != "0"
         and ! string match -q "tmux*" (basename (ps -o command= -p $tmux_fish_ppid))
         set tmux_fish_pid $tmux_fish_ppid
     end


### PR DESCRIPTION
Sometimes, the `__done_is_tmux_window_active` function will try to access the root process (`PID 1`). It is happening to me using `byobu` (`tmux`). 
When that happens(`tmux_fish_pid=1`), `ps -o ppid= -p $tmux_fish_pid | string trim` will return `0`, causing a failure when we access `basename (ps -o command= -p $tmux_fish_ppid)`
To ensure we don't get ugly errors if that is the case, we can check it we reached that case before checking the process' `basename`.

There might be a better solution, this is just a quick fix, so if someone with better `fish` skills has a better suggestion, I am open to changes :+1: 