### PR TITLE
Fix errors when done is run inside tmux

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -116,7 +116,10 @@ function __done_is_tmux_window_active
     # ppid == "tmux" -> break
     set tmux_fish_pid $fish_pid
     while set tmux_fish_ppid (ps -o ppid= -p $tmux_fish_pid | string trim)
-        and ! string match -q "tmux*" (basename (ps -o command= -p $tmux_fish_ppid))
+        # remove leading hyphen so that basename does not treat it as an argument (e.g. -fish), and return only
+        # the actual command and not its arguments so that basename finds the correct command name.
+        # (e.g. '/usr/bin/tmux' from command '/usr/bin/tmux new-session -c /some/start/dir')
+        and ! string match -q "tmux*" (basename (ps -o command= -p $tmux_fish_ppid | string replace -r '^-' '' | string split ' ')[1])
         set tmux_fish_pid $tmux_fish_ppid
     end
 


### PR DESCRIPTION
If tmux is started with a start directory (e.g. /usr/bin/tmux
new-session -c /some/start/dir), then basename in
__done_is_tmux_window_active will fail to extract tmux and thus fail to
identify the process as tmux.

Tmux also starts fish as a login shell, leading to the process name
being '-fish'. When passing this to basename, it interpets the hyphen as
an option being passed to basename.