### PR TITLE
Allow to set the notification expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ set -U __done_notification_urgency_level_failure normal
 ```fish
 set -U __done_allow_nongraphical 1
 ```
-#### For Linux, set the timeout in milliseconds at which to expire the notification. The default is "0" (never expire).
+#### For Linux (except Ubuntu's Notify OSD), set the timeout in milliseconds at which to expire the notification. The default is "3000" (3 seconds). Set to "0" if you want it to never expire.
 
 ```fish
-set -U __done_expire_time 3000 # 3 seconds
+set -U __done_notification_duration 5000 # 5 seconds
 ```
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ set -U __done_notification_urgency_level_failure normal
 ```fish
 set -U __done_allow_nongraphical 1
 ```
+#### For Linux, set the timeout in milliseconds at which to expire the notification. The default is "0" (never expire).
 
+```fish
+set -U __done_expire_time 3000 # 3 seconds
+```
 ## Support
 
 - [fish](https://fishshell.com) 2.3.0+

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -200,6 +200,7 @@ if set -q __done_enabled
     set -q __done_notify_sound; or set -g __done_notify_sound 0
     set -q __done_sway_ignore_visible; or set -g __done_sway_ignore_visible 0
     set -q __done_tmux_pane_format; or set -g __done_tmux_pane_format '[#{window_index}]'
+    set -q __done_expire_time; or set -g __done_expire_time 0
 
     function __done_started --on-event fish_preexec
         set __done_initial_window_id (__done_get_focused_window_id)
@@ -282,7 +283,7 @@ if set -q __done_enabled
                     end
                 end
 
-                notify-send --hint=int:transient:1 --urgency=$urgency --icon=utilities-terminal --app-name=fish "$title" "$message"
+                notify-send --hint=int:transient:1 --urgency=$urgency --icon=utilities-terminal --app-name=fish --expire-time=$__done_expire_time "$title" "$message"
 
                 if test "$__done_notify_sound" -eq 1
                     echo -e "\a" # bell sound

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -200,7 +200,7 @@ if set -q __done_enabled
     set -q __done_notify_sound; or set -g __done_notify_sound 0
     set -q __done_sway_ignore_visible; or set -g __done_sway_ignore_visible 0
     set -q __done_tmux_pane_format; or set -g __done_tmux_pane_format '[#{window_index}]'
-    set -q __done_expire_time; or set -g __done_expire_time 0
+    set -q __done_notification_duration; or set -g __done_notification_duration 3000
 
     function __done_started --on-event fish_preexec
         set __done_initial_window_id (__done_get_focused_window_id)
@@ -283,7 +283,7 @@ if set -q __done_enabled
                     end
                 end
 
-                notify-send --hint=int:transient:1 --urgency=$urgency --icon=utilities-terminal --app-name=fish --expire-time=$__done_expire_time "$title" "$message"
+                notify-send --hint=int:transient:1 --urgency=$urgency --icon=utilities-terminal --app-name=fish --expire-time=$__done_notification_duration "$title" "$message"
 
                 if test "$__done_notify_sound" -eq 1
                     echo -e "\a" # bell sound


### PR DESCRIPTION
Allows to define the notification expiry on linux (when using `notify-send`).
By default it's set to `0` so the behavior isn't changed.
As added in readme, here is an example:
```fish
set -U __done_expire_time 3000 # 3 seconds
```