### PR TITLE
Fix failure in tmux detection

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -116,7 +116,7 @@ function __done_is_tmux_window_active
     # ppid == "tmux" -> break
     set tmux_fish_pid $fish_pid
     while set tmux_fish_ppid (ps -o ppid= -p $tmux_fish_pid | string trim)
-        and ! string match -q "tmux*" (basename (ps -o command= -p $tmux_fish_ppid))
+        and ! string match -q "tmux*" (basename (ps -o exe= -p $tmux_fish_ppid))
         set tmux_fish_pid $tmux_fish_ppid
     end
 


### PR DESCRIPTION
Obtaining process name with `basename (ps -o command= -p $tmux_fish_ppid)`
could fail.

Let's suppose tmux was launched as `tmux new-session -c /path/to/dir`.
The ps command would return `tmux new-session -c /path/to/dir`, and the result
of taking basename of it would be `dir`, which is not what we expect.

In my opinion, the ps command should return a file path because basename
command is used.  Prior to the commit 346adbe63714d859aa7fbcfe1fb799de34ddf16c,
ps was given `-o exe=` instead of `-o command=`.  With `-o exe=`, ps returns a
path to the tmux executable, and we don't need to care about what kinds of
arguments were passed to tmux.

At the moment, the pull request #124 also tries to solve the same problem.
However, I think this solution is better because it doesn't need to consider
problematic argument patterns in advance.

Having said that, because I don't know why that commit (346adbe) replaced
`-o exe=` with `-o command=`, there is a possibility that this commit might
cause another problem.  It would be better to clarify the reason before merge.