### PR TITLE
Use `fish_postexec` instead of `fish_prompt`

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -199,7 +199,7 @@ if set -q __done_enabled
         set __done_initial_window_id (__done_get_focused_window_id)
     end
 
-    function __done_ended --on-event fish_prompt
+    function __done_ended --on-event fish_postexec
         set -l exit_status $status
 
         # backwards compatibility for fish < v3.0
@@ -208,14 +208,14 @@ if set -q __done_enabled
         if test $cmd_duration
             and test $cmd_duration -gt $__done_min_cmd_duration # longer than notify_duration
             and not __done_is_process_window_focused # process pane or window not focused
-            and not string match -qr $__done_exclude $history[1] # don't notify on git commands which might wait external editor
+            and not string match -qr $__done_exclude $argv[1] # don't notify on git commands which might wait external editor
 
             # Store duration of last command
             set -l humanized_duration (__done_humanize_duration "$cmd_duration")
 
             set -l title "Done in $humanized_duration"
             set -l wd (string replace --regex "^$HOME" "~" (pwd))
-            set -l message "$wd/ $history[1]"
+            set -l message "$wd/ $argv[1]"
             set -l sender $__done_initial_window_id
 
             if test $exit_status -ne 0


### PR DESCRIPTION
Using the `fish_postexec` event removes the reliance on `history` as the command that just finished executing is passed in as the first argument to the function. The `fish_prompt` event is also fired when we don't need to run.