### PR TITLE
Kitty specific is_process_window_focused impl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ set -U __done_notification_urgency_level_failure normal
 ```fish
 set -U __done_allow_nongraphical 1
 ```
+
+#### Notifications are unavailable under Wayland. However, if you are using Kitty, you can enable it by using Kitty's remote control.
+
+You need to install jq (jqlang.github.io/jq).
+
+In kitty.conf (change "kitty-rc-password" to your liking):
+
+```conf
+remote_control_password "kitty-rc-password" ls
+allow_remote_control password
+```
+
+In fish
+
+```fish
+set -U __done_kitty_remote_control 1
+set -U __done_kitty_remote_control_password "kitty-rc-password"
+```
+
 #### For Linux (except Ubuntu's Notify OSD), set the timeout in milliseconds at which to expire the notification. The default is "3000" (3 seconds). Set to "0" if you want it to never expire.
 
 ```fish

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -137,6 +137,11 @@ function __done_is_process_window_focused
     if set -q __done_allow_nongraphical
         return 1
     end
+    
+    if set -q __done_kitty_remote_control
+        kitty @ --password="$__done_kitty_remote_control_password" ls | jq -e ".[].tabs.[] | select(any(.windows.[]; .is_self)) | .is_focused" > /dev/null
+        return $status
+    end
 
     set __done_focused_window_id (__done_get_focused_window_id)
     if test "$__done_sway_ignore_visible" -eq 1


### PR DESCRIPTION
This uses Kitty's remote control protocol to get the window state, so it works under Wayland.

The user can enable it by setting `__done_kitty_remote_control=1` and enable `allow_remote_control` in `kitty.conf`.

Compared to the default implementation, it will send a notification when the window is focused, but the current tab is not. If this is desired, the user may want to enable this on Kitty+X11, too.