### PR TITLE
Use kitty's new o=invisible option in notification protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,14 @@ set -U __done_notification_urgency_level_failure normal
 set -U __done_allow_nongraphical 1
 ```
 
-#### Notifications are unavailable under Wayland. However, if you are using Kitty, you can enable it by using Kitty's remote control.
+
+#### Notifications are unavailable under Wayland. However, if you are using Kitty 0.31 or newer, you can use Kitty's own notification protocol.
+
+```fish
+set -U __done_kitty_notification_unfocused 1
+```
+
+##### If you are using an older version of Kitty, you can use Kitty's remote control protocol instead.
 
 You need to install [jq](https://jqlang.github.io/jq).
 

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -138,6 +138,10 @@ function __done_is_process_window_focused
         return 1
     end
 
+    if set -q __done_kitty_notification_unfocused
+        return 1
+    end
+
     if set -q __done_kitty_remote_control
         kitty @ --password="$__done_kitty_remote_control_password" ls | jq -e ".[].tabs.[] | select(any(.windows.[]; .is_self)) | .is_focused" >/dev/null
         return $status
@@ -250,7 +254,11 @@ if set -q __done_enabled
                     echo -e "\a" # bell sound
                 end
             else if set -q KITTY_WINDOW_ID
-                printf "\x1b]99;i=done:d=0;$title\x1b\\"
+                if set -q __done_kitty_notification_unfocused
+                    printf "\x1b]99;i=done:d=0:o=invisible;$title\x1b\\"
+                else
+                    printf "\x1b]99;i=done:d=0;$title\x1b\\"
+                end
                 printf "\x1b]99;i=done:d=1:p=body;$message\x1b\\"
             else if type -q terminal-notifier # https://github.com/julienXX/terminal-notifier
                 if test "$__done_notify_sound" -eq 1


### PR DESCRIPTION
It's a new feature in Kitty 0.31 (which is just released). With that option, the notification is ignored if the window is focused and the tab is active, so we don't have to detect window state.

There's no reliable way to detect Kitty's version, so the user needs to `set -U kitty_notification_unfocused 1`.