### PR TITLE
Fix support for jq 1.6

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -139,7 +139,7 @@ function __done_is_process_window_focused
     end
 
     if set -q __done_kitty_remote_control
-        kitty @ --password="$__done_kitty_remote_control_password" ls | jq -e ".[].tabs.[] | select(any(.windows.[]; .is_self)) | .is_focused" >/dev/null
+        kitty @ --password="$__done_kitty_remote_control_password" ls | jq -e ".[].tabs[] | select(any(.windows[]; .is_self)) | .is_focused" >/dev/null
         return $status
     end
 


### PR DESCRIPTION
Ubuntu still ships jq 1.6 which does not support '.[].tabs.[]' syntax. Support for this syntax was added later. In this PR we change this to '.[].tabs[]' which should work both in older and newer version of jq.

Here is some context about this issue in jq:
https://github.com/jqlang/jq/issues/2517#issuecomment-1380754288