### PR TITLE
Fix Hyprland window ID detection

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -83,7 +83,7 @@ function __done_get_focused_window_id
         and type -q jq
         swaymsg --type get_tree | jq '.. | objects | select(.focused == true) | .id'
     else if test -n "$HYPRLAND_INSTANCE_SIGNATURE"
-        hyprctl activewindow | awk 'NR==13 {print $2}'
+        hyprctl activewindow | awk 'NR==1 {print $2}'
     else if begin
             test "$XDG_SESSION_DESKTOP" = gnome; and type -q gdbus
         end

--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -152,7 +152,7 @@ function __done_is_process_window_focused
         string match --quiet --regex "^true" (swaymsg -t get_tree | jq ".. | objects | select(.id == "$__done_initial_window_id") | .visible")
         return $status
     else if test -n "$HYPRLAND_INSTANCE_SIGNATURE"
-        and test $__done_initial_window_id -eq (hyprctl activewindow | awk 'NR==13 {print $2}')
+        and test $__done_initial_window_id = (hyprctl activewindow | awk 'NR==1 {print $2}')
         return $status
     else if test "$__done_initial_window_id" != "$__done_focused_window_id"
         return 1


### PR DESCRIPTION
PID reporting is not accurate, as it returns parent's PID. This would show up when running Foot terminal in server mode, where it would return the same PID (server's) for every client window. Using window address to identify the window fixes this.
