### PR TITLE
fix: dont print errors to stdout when no window id found

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -149,7 +149,7 @@ function __done_is_process_window_focused
     set __done_focused_window_id (__done_get_focused_window_id)
     if test "$__done_sway_ignore_visible" -eq 1
         and test -n "$SWAYSOCK"
-        string match --quiet --regex "^true" (swaymsg -t get_tree | jq ".. | objects | select(.id == "$__done_initial_window_id") | .visible")
+        string match --quiet --regex "^true" (swaymsg -t get_tree | jq ".. | objects | select(.id == "$__done_initial_window_id") | .visible" 2>/dev/null)
         return $status
     else if test -n "$HYPRLAND_INSTANCE_SIGNATURE"
         and test $__done_initial_window_id = (hyprctl activewindow | awk 'NR==1 {print $2}')


### PR DESCRIPTION
Sometimes when running a command this error is spewed onto the console:
```
jq: error: syntax error, unexpected ')' (Unix shell quoting issues?) at <top-level>, line 1:
.. | objects | select(.id == ) | .visible
jq: 1 compile error
```

This reproduces every time for me: `fisher update; and fish_update_completions`
(this is actually the only time it happens for me)

This is because `$__done_initial_window_id` is empty `''` and thus causing the jq filter to fail.

Regardless of whether window ID can be empty or not, the jq command stderr should be suppressed as all we care about is the exit status.