### PR TITLE
Fix NSNotificationCenter connection invalid

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -226,6 +226,11 @@ if set -q __done_enabled
         # backwards compatibility for fish < v3.0
         set -q cmd_duration; or set -l cmd_duration $CMD_DURATION
 
+        # on macOS, NSNotificationCenter connection is invalid when user is not console user
+        test (uname -s) = 'Darwin'
+        and test (stat -f '%Su' /dev/console) != "$USER"
+        and return
+
         if test $cmd_duration
             and test $cmd_duration -gt $__done_min_cmd_duration # longer than notify_duration
             and not __done_is_process_window_focused # process pane or window not focused


### PR DESCRIPTION
This PR is a workaround proposal for issue #149 specific to NotificationCenter on macOS.

When the effective user isn't the console user, [terminal-notifier](https://github.com/julienXX/terminal-notifier) or built-in `osascript` command will print an error and likely wait forever in NSRunLoop.

As a consequence, the user has to interrupt `__done_ended` with control-C to continue.

When `terminal-notifier` is installed, the error message looks like:

```text
2025-09-04 04:13:50.851 terminal-notifier[94710:6362240] NSNotificationCenter connection invalid
```

Else, when `done` falls back to `osascript`, the error message looks like:

```
78:79: syntax error: Expected “"” but found unknown token. (-2741)
```

The latter cryptic error message is a true Darwin award winner (pun intended).

The code is added after `exit_status` and `cmd_duration` to preserve their values.

The current proposal is:

* when `uname -s` prints `Darwin`
  i.e. user is running macOS
* and `/dev/console` owner is not `$USER`
  i.e. shell user is not macOS graphical interface user (ex: effective user is root)
* then `__fish_ended` returns

I am not a [Kitty](https://sw.kovidgoyal.net/kitty/) user: it is possible Kitty users don't have the issue and stop receiving other users notifications.

I don't own a Linux desktop: it is possible `notify-send` or `notify-desktop` share similar security boundaries than NotificationCenter on macOS.