### PR TITLE
Avoid spawning subprocesses on startup to probe graphical capabilities

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -76,6 +76,18 @@ function __done_windows_notification -a title -a message
 "
 end
 
+function __done_can_get_window_id
+    # Lightweight capability check using only builtins and env vars.
+    # Avoids spawning subprocesses on every shell startup (~20ms on macOS).
+    type -q lsappinfo # macOS
+        or test -n "$SWAYSOCK" # Sway
+        or test -n "$HYPRLAND_INSTANCE_SIGNATURE" # Hyprland
+        or test -n "$NIRI_SOCKET" # Niri
+        or begin; test "$XDG_SESSION_DESKTOP" = gnome; and type -q gdbus; end # GNOME
+        or begin; type -q xprop; and test -n "$DISPLAY"; end # X11
+        or set -q __done_allow_nongraphical
+end
+
 function __done_get_focused_window_id
     if type -q lsappinfo
         lsappinfo info -only bundleID (lsappinfo front | string replace 'ASN:0x0-' '0x') | cut -d '"' -f4
@@ -197,8 +209,11 @@ function __done_humanize_duration -a milliseconds
 end
 
 # verify that the system has graphical capabilities before initializing
+# Use lightweight checks (builtins/env vars) instead of spawning subprocesses,
+# since this runs on every shell startup. The actual window ID is fetched
+# on-demand in __done_started and __done_is_process_window_focused.
 if test -z "$SSH_CLIENT" # not over ssh
-    and count (__done_get_focused_window_id) >/dev/null # is able to get window id
+    and __done_can_get_window_id
     set __done_enabled
 end
 


### PR DESCRIPTION
## Summary

The initialization code (line 200-202) calls `__done_get_focused_window_id` on every interactive shell startup just to check whether the system *can* get a window ID. On macOS this spawns two `lsappinfo` processes (~20ms); on Linux/X11 it may spawn `xprop`.

This PR adds a lightweight `__done_can_get_window_id` function that uses only fish builtins (`type -q`, `test -n`) and environment variables to check capability — zero subprocess cost. The checks mirror each branch of `__done_get_focused_window_id`:

| Platform | Probe |
|----------|-------|
| macOS | `type -q lsappinfo` |
| Sway | `test -n "$SWAYSOCK"` |
| Hyprland | `test -n "$HYPRLAND_INSTANCE_SIGNATURE"` |
| Niri | `test -n "$NIRI_SOCKET"` |
| GNOME | `test "$XDG_SESSION_DESKTOP" = gnome; and type -q gdbus` |
| X11 | `type -q xprop; and test -n "$DISPLAY"` |
| Non-graphical | `set -q __done_allow_nongraphical` |

The actual window ID is already fetched on-demand in `__done_started` (fish_preexec) and `__done_is_process_window_focused` (fish_postexec), so the startup call was purely a capability gate.

## Impact

Saves ~20ms of interactive shell startup time on macOS (measured with `fish --profile-startup`).

## WSL note

The old code also had a WSL check (`uname -a | string match microsoft`), which itself spawns a subprocess. The new code omits this from the capability check — WSL users can set `__done_allow_nongraphical` + `__done_notification_command`, which is already the recommended WSL configuration. If WSL support is needed in the capability check without a subprocess, we could check for the existence of `/proc/sys/fs/binfmt_misc/WSLInterop` instead.