### PR TITLE
Silence the graphical-capability probe's stderr

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -201,7 +201,7 @@ end
 
 # verify that the system has graphical capabilities before initializing
 if test -z "$SSH_CLIENT" # not over ssh
-    and count (__done_get_focused_window_id) >/dev/null # is able to get window id
+    and count (__done_get_focused_window_id 2>/dev/null) >/dev/null # is able to get window id
     set __done_enabled
 end
 


### PR DESCRIPTION
Fixes #172.

## Problem

The init-time graphical-capability probe redirects stdout but not stderr:

```fish
and count (__done_get_focused_window_id) >/dev/null # is able to get window id
```

When `__done_get_focused_window_id` can run but fails, its error prints at **every interactive shell start**, even though the probe then correctly concludes "not graphical" and disables done. On GNOME with an unreachable session bus (a sandbox, a container, a degraded session), that's one line of noise per shell:

```
Error connecting: Could not connect: Permission denied
```

The same applies to any failing branch of the helper (`swaymsg`, `hyprctl`, `xprop`, …).

## Fix

Redirect the probe's stderr inside the command substitution. A capability probe should decide quietly; errors during actual notification delivery are unaffected, since this touches only the init-time check.

## Testing

`fishtape test/done.fish` passes locally; also verified interactively that a shell with an unreachable session bus starts silently and a normal GNOME shell still enables done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)