### PR TITLE
Fix Niri focus detection with tmux

### DIFF
--- a/conf.d/done.fish
+++ b/conf.d/done.fish
@@ -133,7 +133,9 @@ function __done_is_tmux_window_active
 
     # tmux session attached and window is active -> no notification
     # all other combinations -> send notification
-    tmux list-panes -a -F "#{session_attached} #{window_active} #{pane_pid}" | string match -q "1 1 $tmux_fish_pid"
+    tmux list-panes -a \
+        -F "#{session_attached} #{window_active} #{pane_active} #{pane_pid}" |
+        string match -q "1 1 1 $tmux_fish_pid"
 end
 
 function __done_is_screen_window_active
@@ -161,8 +163,9 @@ function __done_is_process_window_focused
         and test "$__done_initial_window_id" = (hyprctl activewindow | awk 'NR==1 {print $2}')
         return $status
     else if test -n "$NIRI_SOCKET"
-        and test "$__done_initial_window_id" = (niri msg --json focused-window | jq ".id")
-        return $status
+        if test "$__done_initial_window_id" != (niri msg --json focused-window | jq ".id")
+            return 1
+        end
     else if test "$__done_initial_window_id" != "$__done_focused_window_id"
         return 1
     end


### PR DESCRIPTION
# Fix Niri focus detection with tmux

Fixes #170

This changes focus detection so that Niri and tmux focus state are considered together.

Previously, when the Niri window containing tmux remained focused, the Niri-specific branch returned before tmux focus detection could determine whether the original tmux window was still active.

The Niri check now returns early only when the Niri window is no longer focused. Otherwise, focus detection continues to the tmux check.

The tmux check also includes `pane_active`, allowing `done` to distinguish between panes within the same tmux window.

Tested manually with:

* same Niri window and same tmux pane: no notification
* same Niri window and different tmux pane: notification
* same Niri window and different tmux window: notification
* different Niri window: notification
* outside tmux, same Niri window: no notification
* outside tmux, different Niri window: notification
